### PR TITLE
Address incompatible Ruff rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -47,7 +47,7 @@ select = [
 ]
 
 # Docstring rules are too strict, ignore these rules:
-ignore = ["D100", "D107", "D205", "D407", "D413"]
+ignore = ["D100", "D107", "D203", "D205", "D213", "D407", "D413"]
 
 fixable = ["ALL"]
 


### PR DESCRIPTION
Closes https://github.com/NationalCentreTruthReconciliation/Python-Development-Guide/issues/1

- Opting for [Rule D211](https://docs.astral.sh/ruff/rules/blank-line-before-class/) over [Rule D203](https://docs.astral.sh/ruff/rules/one-blank-line-before-class/)
- Opting for [Rule D212](https://docs.astral.sh/ruff/rules/multi-line-summary-first-line/) over [Rule D213](https://docs.astral.sh/ruff/rules/multi-line-summary-second-line/)